### PR TITLE
Check unsupported workspace using git rev-parse

### DIFF
--- a/lib/core/workspace.rb
+++ b/lib/core/workspace.rb
@@ -9,7 +9,7 @@ module VagrantGitSyncModule
       def initialize(env)
         @env = env
         @vagrant_cwd = env[:env].cwd.to_s.strip.chomp('/')
-        if File.exist?("#{@vagrant_cwd}/.git") and Workspace.git_installed
+        if system('git rev-parse 2> /dev/null > /dev/null')==true and Workspace.git_installed
           @unsupported_workspace = false
         else
           @unsupported_workspace = true


### PR DESCRIPTION
Check unsupported workspace using git rev-parse to determine if directory is under git control.
This allows vagrant_cwd to be in any directory under git control without the need to have a .git at the same level.